### PR TITLE
Added a dark theme option for bed-time reading.

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/Helpers.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/Helpers.java
@@ -1,5 +1,8 @@
 package fr.gaulupeau.apps.Poche;
 
+import android.app.Activity;
+import android.widget.ImageView;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -9,6 +12,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import fr.gaulupeau.apps.InThePoche.R;
 
 public class Helpers {
 
@@ -49,4 +54,17 @@ public class Helpers {
 
 		return res;
 	}
+
+    public void setNightViewTheme(boolean nightmode, Activity a) {
+        if (nightmode) {
+            a.setTheme(R.style.app_theme_dark);
+        }
+    }
+
+    public void setNightViewIcon(boolean nightmode, ImageView imageView) {
+        if (nightmode) {
+            //invert colors
+            imageView.setImageResource(R.drawable.welcome_night);
+        }
+    }
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ListArticles.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ListArticles.java
@@ -1,6 +1,5 @@
 package fr.gaulupeau.apps.Poche;
 
-import android.annotation.TargetApi;
 import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -35,7 +34,11 @@ public class ListArticles extends BaseActionBarActivity {
 		super.onCreate(savedInstanceState);
         //11.09.2015 Nightmode
         nightmode = getIntent().getBooleanExtra("NIGHTMODE", false);
-        setNightViewTheme();
+        if (nightmode) {
+            Helpers myHelper = new Helpers();
+            myHelper.setNightViewTheme(nightmode, this);
+        }
+
         setContentView(R.layout.list);
         readList = (ListView) findViewById(R.id.liste_articles);
         ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(this);
@@ -57,8 +60,8 @@ public class ListArticles extends BaseActionBarActivity {
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		MenuInflater inflater = getMenuInflater();
-		inflater.inflate(R.menu.option_list, menu);
-		return true;
+        inflater.inflate(R.menu.option_list, menu);
+        return true;
 	}
 
     @Override
@@ -123,7 +126,6 @@ public class ListArticles extends BaseActionBarActivity {
                 filter, null, null, null, ARTICLE_DATE + " DESC");
     }
 
-    // @TargetApi(11)
     private MyCursorAdapter getCursorAdapter() {
         int layout = R.layout.article_list;
         String[] columns = new String[]{ARTICLE_TITLE, ARTICLE_URL};
@@ -139,20 +141,12 @@ public class ListArticles extends BaseActionBarActivity {
     }
      */
 
-    private void setNightViewTheme() {
-        if (nightmode) {
-            this.setTheme(R.style.app_theme_dark);
-        }
-    }
 
-    //extend the SimpleCursorAdapter to create a custom class where we
-    //can override the getView to change the row colors
-    @TargetApi(11)
     private class MyCursorAdapter extends SimpleCursorAdapter {
 
         public MyCursorAdapter(android.content.Context context, int layout, Cursor c,
-                               String[] from, int[] to, int flags) {
-            super(context, layout, c, from, to, flags);
+                               String[] a, int[] b, int flags) {
+            super(context, layout, c, a, b, flags);
         }
 
         @Override

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/Poche.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/Poche.java
@@ -129,9 +129,11 @@ public class Poche extends Activity implements FeedUpdaterInterface {
                 showToast(getString(R.string.txtNetOffline));
             }
         } else {
-            setNightViewTheme();
+            Helpers myHelper = new Helpers();
+            myHelper.setNightViewTheme(nightmode, this);
             setContentView(R.layout.main);
-            setNightViewIcon();
+            ImageView imageView = (ImageView) findViewById(R.id.imageView1);
+            myHelper.setNightViewIcon(nightmode, imageView);
 
             checkAndHandleAfterUpdate();
 
@@ -217,8 +219,8 @@ public class Poche extends Activity implements FeedUpdaterInterface {
     }
 
     private void getDatabase() {
-	    if (database == null) {
-		    ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(this);
+        if (database == null || !database.isOpen()) {
+            ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(this);
 		    database = helper.getReadableDatabase();
 	    }
     }
@@ -231,6 +233,7 @@ public class Poche extends Activity implements FeedUpdaterInterface {
         if (!action.equals(Intent.ACTION_SEND)) {
             updateUnread();
         }
+
     }
 
     @Override
@@ -244,9 +247,11 @@ public class Poche extends Activity implements FeedUpdaterInterface {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (database != null) {
+        if (database.isOpen()) {
             database.close();
         }
+
+
     }
 
     private void updateUnread() {
@@ -254,11 +259,13 @@ public class Poche extends Activity implements FeedUpdaterInterface {
             public void run() {
                 ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(getApplicationContext());
                 getDatabase();
-                if (database.isOpen()) { //Avoid attempt to re-open an already-closed object: SQLiteDatabase
-                    //there should be a better way to make sure, that the unread post count lookup waits until the database is available again
+                if (database.isOpen()) {
                     int news = database.query(ARTICLE_TABLE, null, ARCHIVE + "=0", null, null, null, null).getCount();
                     btnGetPost.setText(String.format(getString(R.string.btnGetPost), news));
+                } else {
+                    btnGetPost.setText(R.string.btnGetPost + "?");
                 }
+
             }
         });
     }
@@ -300,26 +307,4 @@ public class Poche extends Activity implements FeedUpdaterInterface {
         findViewById(R.id.progressBar1).setVisibility(View.GONE);
     }
 
-    private void setNightViewIcon() {
-        ImageView imageView = (ImageView) findViewById(R.id.imageView1);
-        if (nightmode) {
-            //invert colors
-            imageView.setImageResource(R.drawable.welcome_night);
-            this.setTheme(R.style.app_theme_dark);
-        } else {
-            //reset to original
-            imageView.setImageResource(R.drawable.welcome);
-        }
-    }
-
-    private void setNightViewTheme() {
-        if (nightmode) {
-            this.setTheme(R.style.app_theme_dark);
-        }
-    }
-
-    public void setBackgroundColor(int color) {
-        View view = this.getWindow().getDecorView();
-        view.setBackgroundColor(color);
-    }
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ReadArticle.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ReadArticle.java
@@ -41,8 +41,10 @@ public class ReadArticle extends BaseActionBarActivity {
 			id = String.valueOf(data.getLong("id"));
 			nightmode = data.getBoolean("NIGHTMODE", false);
 		}
-		setNightViewTheme();
-
+		if (nightmode) {
+			Helpers myHelper = new Helpers();
+			myHelper.setNightViewTheme(nightmode, this);
+		}
 		setContentView(R.layout.article);
 		view = (ScrollView) findViewById(R.id.scroll);
 		if (nightmode) {
@@ -150,11 +152,5 @@ public class ReadArticle extends BaseActionBarActivity {
 	protected void onDestroy() {
 		super.onDestroy();
 		database.close();
-	}
-
-	private void setNightViewTheme() {
-		if (nightmode) {
-			this.setTheme(R.style.app_theme_dark);
-		}
 	}
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/Settings.java
@@ -29,7 +29,10 @@ public class Settings extends BaseActionBarActivity {
 		super.onCreate(savedInstanceState);
         //11.09.2015 Nightmode
         nightmode = getIntent().getBooleanExtra("NIGHTMODE", false);
-        setNightViewTheme();
+        if (nightmode) {
+            Helpers myHelper = new Helpers();
+            myHelper.setNightViewTheme(nightmode, this);
+        }
         setContentView(R.layout.settings);
         //need to set the background to black separatley from setting the dark theme - why?
         if (nightmode) {
@@ -70,9 +73,4 @@ public class Settings extends BaseActionBarActivity {
 		}
 	}
 
-    private void setNightViewTheme() {
-        if (nightmode) {
-            this.setTheme(R.style.app_theme_dark);
-        }
-    }
 }


### PR DESCRIPTION
Because of the API 8 compability, a restart is needed to take the dark theme in effect (recreate() is only available from API 11 on
+ removed the "attempt to re-open an already-closed object: SQLiteDatabase" error in version 1.8

Optimized my code for the function setNightViewTheme()